### PR TITLE
Explicitly make policy jars readable by all users

### DIFF
--- a/pods/pod_JAVA/lib/lib_doStuff_remotely.bash
+++ b/pods/pod_JAVA/lib/lib_doStuff_remotely.bash
@@ -12,5 +12,6 @@ function lib_doStuff_remotely_installJavaSecurity(){
 
 unzip ${java_security_zip_file} &>/dev/null
 mv UnlimitedJCEPolicyJDK8/*.jar  ${UNTAR_FOLDER}${SOFTWARE_VERSION}/lib/security/
+chmod 0644 ${UNTAR_FOLDER}${SOFTWARE_VERSION}/lib/security/*.jar
 rm -rf UnlimitedJCEPolicyJDK8/
 }


### PR DESCRIPTION
This should prevent problems when admin has `umask 077`, or something like...
