### PR TITLE
Another way to enable unlimited crypto policy

### DIFF
--- a/pods/pod_JAVA/lib/lib_doStuff_remotely.bash
+++ b/pods/pod_JAVA/lib/lib_doStuff_remotely.bash
@@ -8,12 +8,8 @@
 
 function lib_doStuff_remotely_installJavaSecurity(){
 
-## install from local tar to the designated java folder
-
-unzip ${java_security_zip_file} &>/dev/null
-mv UnlimitedJCEPolicyJDK8/*.jar  ${UNTAR_FOLDER}${SOFTWARE_VERSION}/lib/security/
-chmod 0644 ${UNTAR_FOLDER}${SOFTWARE_VERSION}/lib/security/*.jar
-rm -rf UnlimitedJCEPolicyJDK8/
+    ## Uncomment corresponding line in the security policy
+    sed -i '' -e 's|^#crypto.policy=unlimited|crypto.policy=unlimited|' ${UNTAR_FOLDER}${SOFTWARE_VERSION}/lib/security/java.security
 }
 
 # ---------------------------------------


### PR DESCRIPTION
starting with Java 8 build 151, you only need to uncomment line

    #crypto.policy=unlimited

in the `jre/lib/security/java.security` file. More details are at
https://golb.hplar.ch/p/JCE-policy-changes-in-Java-SE-8u151-and-8u152 Also, per
https://bugs.openjdk.java.net/browse/JDK-8170157, starting with Java 8 b162, unlimited policy is
enabled by default.